### PR TITLE
add #29 サンプルページ3から専門用語集へのページ遷移

### DIFF
--- a/u_22_procon/lib/samplePage3.dart
+++ b/u_22_procon/lib/samplePage3.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'tech_term.dart'; // tech_term.dartのインポート
 
 class Samplepage3 extends StatelessWidget {
   const Samplepage3({super.key});
@@ -10,6 +11,17 @@ class Samplepage3 extends StatelessWidget {
       body: const Center(
         child: Text('サンプルページ3'),
       ),
+      floatingActionButton: FloatingActionButton(
+        onPressed: () {
+          Navigator.push(
+            context,
+            MaterialPageRoute(builder: (context) => TechTermPage()),
+          );
+        },
+        child: const Icon(Icons.add),
+      ),
+      floatingActionButtonLocation:
+          FloatingActionButtonLocation.endFloat, // ボタンの位置を右下に設定
     );
   }
 }

--- a/u_22_procon/lib/tech_term.dart
+++ b/u_22_procon/lib/tech_term.dart
@@ -1,0 +1,17 @@
+import 'package:flutter/material.dart';
+
+class TechTermPage extends StatelessWidget {
+  const TechTermPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('専門用語集'),
+      ),
+      body: const Center(
+        child: Text('はよ開発せい'),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
<!-- あくまでテンプレートなので必ずしもすべての項目を埋めなくてよい -->

## 概要

<!-- 変更の目的 もしくは 関連する Issue 番号 -->
- 専門用語集のページが無かったため追加した

## 変更内容

<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->
- サンプルページ3にプラスボタン追加
- tech_term.dartファイルの追加

## 影響範囲

<!-- この関数を変更したのでこの機能にも影響がある、など -->
- サンプルページ3と専門用語集のみ

## 動作要件

<!-- 動作に必要な 環境変数 / 依存関係 / DBの更新 など -->
- 特になし

## 補足

<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
- ボタンを押すとページ遷移が行われる
- フッターとヘッダーがないため何かしらの対処が必要
