### PR TITLE
[fix/#13_deleat_sub] #13 カードに表示するのを用語のみにした

### DIFF
--- a/u_22_procon/lib/subject_term.dart
+++ b/u_22_procon/lib/subject_term.dart
@@ -73,19 +73,17 @@ class subject_term extends StatelessWidget {
                   child: Card(
                     margin: const EdgeInsets.symmetric(vertical:8.0),
                     child:ListTile(
-                    title: Text(
-                      '$term ($subject)',
+                    title: Text(term,
                     style: TextStyle(
                       fontWeight: FontWeight.bold,
-                      color: Colors.grey,
+                      color: Colors.black,
                       ),
                     ),
-                    subtitle: Text(description),
                     onTap: (){
                       showDialog(context: context,
                       builder: (context){
                         return AlertDialog(
-                          title: Text(term),
+                          title: Text('$term\n$subject'),
                           content: Text(description),
                           actions: <Widget>[
                           TextButton(


### PR DESCRIPTION
<!-- あくまでテンプレートなので必ずしもすべての項目を埋めなくてよい -->

## 概要

<!-- 変更の目的 もしくは 関連する Issue 番号 -->
- My用語に表示されるのを用語のみに変更

## 変更内容

<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->
- My用語に表示されるのを用語のみに変更
- 文字の色を黒に
- ポップアップに用語と科目と説明を表記

## 影響範囲

<!-- この関数を変更したのでこの機能にも影響がある、など -->
- 特になし

## 動作要件

<!-- 動作に必要な 環境変数 / 依存関係 / DBの更新 など -->
- 特になし
