### PR TITLE
[updata]#101 科目詳細から科目詳細画面(未設定時)に遷移できるようにした

### DIFF
--- a/u_22_procon/lib/subject_details_updating.dart
+++ b/u_22_procon/lib/subject_details_updating.dart
@@ -238,11 +238,21 @@ class ReadDB extends StatelessWidget {
                         mainAxisAlignment: MainAxisAlignment.spaceBetween,
                         children: [
                           Text('$date曜$period限'),
-                          const Icon(
-                            Icons.screen_rotation_alt_rounded,
-                            color: Colors.black,
-                            size: 32,
-                          ),
+                          IconButton(
+                              onPressed: () {
+                                GoRouter.of(context)
+                                    .go('/classTimetable/subjectDetails');
+                              },
+                              icon: const Icon(
+                                Icons.screen_rotation_alt_rounded,
+                                color: Colors.black,
+                                size: 32,
+                              ))
+                          // const Icon(
+                          //   Icons.screen_rotation_alt_rounded,
+                          //   color: Colors.black,
+                          //   size: 32,
+                          // ),
                         ],
                       ),
                       SizedBox(


### PR DESCRIPTION
<!-- あくまでテンプレートなので必ずしもすべての項目を埋めなくてよい -->

## 概要

<!-- 変更の目的 もしくは 関連する Issue 番号 -->
- 101

## 変更内容

<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->
- 科目詳細画面(設定時)から科目詳細画面(未設定時)へ遷移る右上のグルグルを設置しました。

## 影響範囲

<!-- この関数を変更したのでこの機能にも影響がある、など -->
- x

## 動作要件

<!-- 動作に必要な 環境変数 / 依存関係 / DBの更新 など -->
- x

## 補足

<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
- x
