### PR TITLE
update #45 いいねボタンをユーザーごとに押せるようにしました

### DIFF
--- a/u_22_procon/lib/main.dart
+++ b/u_22_procon/lib/main.dart
@@ -73,7 +73,8 @@ final goRouterProvider = Provider<GoRouter>((ref) {
               GoRoute(
                   path: 'task_answer',
                   builder: (BuildContext context, GoRouterState state) {
-                    return const TaskAnswer();
+                    final data = state.extra as String;
+                    return TaskAnswer(data);
                   }),
               GoRoute(
                 path: 'subject_details_updating',

--- a/u_22_procon/lib/subject_details_updating.dart
+++ b/u_22_procon/lib/subject_details_updating.dart
@@ -130,7 +130,7 @@ class SubjectDetailsUpdating extends StatelessWidget {
                     )),
                 GestureDetector(
                     onTap: () {
-                      GoRouter.of(context).go('/classTimetable/task_answer');
+                      GoRouter.of(context).go('/classTimetable/task_answer', extra:subject);
                     },
                     child: Container(
                       decoration: BoxDecoration(


### PR DESCRIPTION
<!-- あくまでテンプレートなので必ずしもすべての項目を埋めなくてよい -->

## 概要

<!-- 変更の目的 もしくは 関連する Issue 番号 -->
#45 

## 変更内容

<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->
いいねボタンをユーザーごとに押せるようにした．ユーザーごとのいいねの状態を管理し，
いいねを押した状態も残るようになった．

## 影響範囲

<!-- この関数を変更したのでこの機能にも影響がある、など -->
ユーザーや科目の状態が時間割の画面から遷移させたいので，mainと科目詳細画面に画面遷移の点で少し変更あり

## 動作要件

<!-- 動作に必要な 環境変数 / 依存関係 / DBの更新 など -->
firestoreのtasksのフィールドで，いいね数をnumber型からarray型に変更した．
