### PR TITLE
fix #48 写真表示のエラーを修正

### DIFF
--- a/u_22_procon/lib/task_answer.dart
+++ b/u_22_procon/lib/task_answer.dart
@@ -292,14 +292,23 @@ class TaskAnswer extends StatelessWidget {
                               height: 80,
                               width: 80,
                               child: tasks[index].image != ''
-                                  ? FittedBox(
-                                    fit: BoxFit.contain,
-                                    child: Image.network(
-                                      tasks[index].image,
-                                      fit: BoxFit.contain,
-                                    )
-                                  )
-                                  : const Text("No data"),
+                              ? FittedBox(
+                                fit: BoxFit.contain,
+                                child: Image.network(
+                                  tasks[index].image,
+                                  fit: BoxFit.contain,
+                                  errorBuilder: (c, o, s) {
+                                    return const Column(children: [
+                                      Icon(
+                                        Icons.error,
+                                        color: Colors.red,
+                                      ),
+                                      Text("画像が表示できませんでした"),
+                                    ]);
+                                  }
+                                )
+                              )
+                              : const Text("No data"),
                             ),
                             Text(
                               tasks[index].content,


### PR DESCRIPTION
<!-- あくまでテンプレートなので必ずしもすべての項目を埋めなくてよい -->

## 概要

<!-- 変更の目的 もしくは 関連する Issue 番号 -->
#48 

## 変更内容

<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->
写真がエラーで表示されない時，分かりやすくエラーを表示するようにしました